### PR TITLE
Add FastAPI server using DB metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,9 +425,26 @@ python odata_mcp.py --transport http --http-addr 192.168.1.100:8080 --service ht
    curl -X POST http://localhost:8080/rpc \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
-   ```
+  ```
 
 > ⚠️ **Security Warning**: The HTTP/SSE transport does not include authentication. Only use it in secure, trusted environments or behind a reverse proxy with proper authentication.
+
+## FastAPI Deployment
+
+The repository also includes a FastAPI application that reads service details from a SQLite database.
+
+### Environment Variables
+
+- `SERVICE_DB_PATH` - path to the SQLite database (default `shared.sqlite`)
+- `SERVICE_NAME` - name of the service entry to load
+
+### Running
+
+```bash
+uvicorn fastapi_server:app --reload
+```
+
+This server exposes every generated tool as a POST endpoint and publishes a fully formed OpenAPI schema.
 
 ## Architecture
 

--- a/fastapi_server.py
+++ b/fastapi_server.py
@@ -1,0 +1,67 @@
+import os
+import sqlite3
+import json
+import inspect
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, create_model, Field
+
+from odata_mcp_lib import ODataMCPBridge
+
+DB_PATH = os.getenv("SERVICE_DB_PATH", "shared.sqlite")
+SERVICE_NAME = os.getenv("SERVICE_NAME")
+
+if not SERVICE_NAME:
+    raise RuntimeError("SERVICE_NAME environment variable is required")
+
+conn = sqlite3.connect(DB_PATH)
+row = conn.execute(
+    "SELECT base_url, metadata, description FROM services WHERE name=?",
+    (SERVICE_NAME,)
+).fetchone()
+conn.close()
+if not row:
+    raise RuntimeError(f"Service '{SERVICE_NAME}' not found in database")
+
+base_url, metadata_xml, description = row
+
+bridge = ODataMCPBridge(
+    base_url,
+    metadata_xml=metadata_xml,
+    hint=description,
+    verbose=False,
+)
+
+app = FastAPI(title=f"OData MCP API - {SERVICE_NAME}", description=description)
+
+
+def _eval_type(type_hint: str):
+    namespace = {"Optional": Optional, "str": str, "int": int, "float": float, "bool": bool}
+    try:
+        return eval(type_hint, namespace, namespace)
+    except Exception:
+        return Optional[str]
+
+
+for tool_name, func in bridge.all_registered_tools.items():
+    params = bridge.tool_param_defs.get(tool_name, [])
+    fields: Dict[str, tuple] = {}
+    for p in params:
+        t = _eval_type(p["type_hint"])
+        default = ... if p["required"] else None
+        fields[p["name"]] = (t, Field(default=default, description=p.get("description")))
+    ParamModel = create_model(f"{tool_name.capitalize()}Params", **fields)
+
+    async def endpoint(payload: ParamModel, _f=func):
+        try:
+            result = await _f(**payload.dict(exclude_none=True))
+            try:
+                return json.loads(result)
+            except Exception:
+                return {"result": result}
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    app.post(f"/{tool_name}", name=tool_name)(endpoint)
+

--- a/odata_mcp_lib/__init__.py
+++ b/odata_mcp_lib/__init__.py
@@ -29,3 +29,4 @@ __all__ = [
     'NameShortener',
     'HintManager'
 ]
+

--- a/odata_mcp_lib/bridge.py
+++ b/odata_mcp_lib/bridge.py
@@ -36,7 +36,8 @@ from .hint_manager import HintManager
 class ODataMCPBridge:
     """Bridge between OData and MCP, creating tools from OData metadata."""
 
-    def __init__(self, service_url: str, auth: Optional[Union[Tuple[str, str], Dict[str, str]]] = None, mcp_name: str = "odata-mcp", verbose: bool = False, 
+    def __init__(self, service_url: str, auth: Optional[Union[Tuple[str, str], Dict[str, str]]] = None, *, metadata_xml: Optional[str] = None,
+                 mcp_name: str = "odata-mcp", verbose: bool = False,
                  tool_prefix: Optional[str] = None, tool_postfix: Optional[str] = None, use_postfix: bool = True, tool_shrink: bool = False,
                  allowed_entities: Optional[List[str]] = None, allowed_functions: Optional[List[str]] = None, sort_tools: bool = True,
                  pagination_hints: bool = False, legacy_dates: bool = True, verbose_errors: bool = False,
@@ -96,6 +97,7 @@ class ODataMCPBridge:
         self.registered_entity_tools = {}
         self.registered_function_tools = []
         self.all_registered_tools = {}  # Track all tools for trace functionality
+        self.tool_param_defs = {}
         self.use_postfix = use_postfix
         
         # Initialize name shortener
@@ -124,7 +126,10 @@ class ODataMCPBridge:
             self._log_verbose("Initializing Metadata Parser...")
             self.parser = MetadataParser(service_url, auth, verbose=self.verbose)
             self._log_verbose("Parsing OData Metadata...")
-            self.metadata = self.parser.parse()
+            if metadata_xml:
+                self.metadata = self.parser.parse_xml_content(metadata_xml)
+            else:
+                self.metadata = self.parser.parse()
             self._log_verbose("Metadata Parsed. Initializing OData Client...")
             self.client = ODataClient(
                 self.metadata, 
@@ -470,6 +475,8 @@ class ODataMCPBridge:
         
         # Store the implementation logic in the registry
         self._implementation_registry[tool_name] = implementation_logic
+        # Save parameter definitions for FastAPI generation
+        self.tool_param_defs[tool_name] = param_defs
 
         # Prepare scope for exec, including necessary types and modules
         exec_scope = {
@@ -1017,6 +1024,7 @@ class ODataMCPBridge:
             self.mcp.add_tool(Tool.from_function(odata_service_info), name=tool_name)
             # Track the tool for trace functionality
             self.all_registered_tools[tool_name] = odata_service_info
+            self.tool_param_defs[tool_name] = []
             self._log_verbose(f"Registered tool: {tool_name}")
             
             # Also register with 'readme' alias if not using custom name
@@ -1024,6 +1032,7 @@ class ODataMCPBridge:
                 readme_name = self._make_tool_name("readme")
                 self.mcp.add_tool(Tool.from_function(odata_service_info), name=readme_name)
                 self.all_registered_tools[readme_name] = odata_service_info
+                self.tool_param_defs[readme_name] = []
                 self._log_verbose(f"Registered tool alias: {readme_name}")
         except Exception as e:
             # Error, print regardless of verbosity

--- a/odata_mcp_lib/metadata_parser.py
+++ b/odata_mcp_lib/metadata_parser.py
@@ -174,6 +174,46 @@ class MetadataParser:
                 print(f"ERROR: Error during final fallback: {fallback_error}", file=sys.stderr)
                 raise e  # Re-raise the original error
 
+    def parse_xml_content(self, xml_content: str) -> ODataMetadata:
+        """Parse OData metadata from a provided XML string."""
+        entity_types = {}
+        entity_sets = {}
+        function_imports = {}
+        service_description = None
+
+        try:
+            self._log_verbose("Parsing metadata from provided XML string...")
+            try:
+                from defusedxml import lxml as safe_lxml
+                root = safe_lxml.fromstring(xml_content.encode("utf-8"))
+                self._log_verbose("Parsed metadata with defusedxml.")
+            except ImportError:
+                root = etree.fromstring(xml_content.encode("utf-8"))
+                self._log_verbose("Parsed metadata with lxml.")
+
+            schema = root.find('.//edm:Schema', namespaces=NAMESPACES)
+            if schema is not None:
+                service_description = self._get_description(schema)
+
+            entity_types = self._parse_entity_types(root)
+            entity_sets = self._parse_entity_sets(root, entity_types)
+            function_imports = self._parse_function_imports(root)
+
+            self._log_verbose(
+                f"Parsing complete. Found {len(entity_types)} types, {len(entity_sets)} sets, {len(function_imports)} functions."
+            )
+
+            return ODataMetadata(
+                entity_types=entity_types,
+                entity_sets=entity_sets,
+                function_imports=function_imports,
+                service_url=self.service_url,
+                service_description=service_description,
+            )
+        except Exception as e:
+            print(f"FATAL ERROR: Could not parse provided metadata: {e}", file=sys.stderr)
+            raise
+
     def _get_entity_sets_from_service_doc(self) -> Dict[str, EntitySet]:
         """Get entity sets from the service document (AtomPub format)."""
         entity_sets = {}


### PR DESCRIPTION
## Summary
- support parsing metadata from XML string in `MetadataParser`
- allow passing metadata XML to `ODataMCPBridge`
- track tool parameter definitions for FastAPI
- add `fastapi_server.py` to serve generated tools via FastAPI
- document new FastAPI deployment option in README

## Testing
- `pip install -r requirements.txt` *(fails: Failed building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_687fd7c95c7c832b900ac22b1349f89d